### PR TITLE
Fix: MeCard does not allow line breaks

### DIFF
--- a/src/Format/MeCardFormat.php
+++ b/src/Format/MeCardFormat.php
@@ -84,7 +84,7 @@ class MeCardFormat extends AbstractFormat
         $data[] = "BDAY:{$this->birthday};";
         $data[] = "ADR:{$this->address};";
         $data[] = "URL:{$this->url};";
-        $data[] = "NICKNAME:{$this->nickName};\n;";
+        $data[] = "NICKNAME:{$this->nickName};;";
 
         return implode($data);
     }

--- a/src/Format/MeCardFormat.php
+++ b/src/Format/MeCardFormat.php
@@ -86,6 +86,6 @@ class MeCardFormat extends AbstractFormat
         $data[] = "URL:{$this->url};";
         $data[] = "NICKNAME:{$this->nickName};\n;";
 
-        return implode("\n", $data);
+        return implode($data);
     }
 }

--- a/tests/unit/FormatsTest.php
+++ b/tests/unit/FormatsTest.php
@@ -95,8 +95,8 @@ class FormatsTest extends \Codeception\Test\Unit
         $card->url = 'http://2amigos.us';
         $card->nickName = 'tonydspaniard';
 
-        $expected = "MECARD:\nN:Ramirez Antonio;\nSOUND:docomotaro;\nTEL:657657657;\nTEL-AV:657657657;\nEMAIL:hola@2amigos.us;\n" .
-            "NOTE:test-note;\nBDAY:19711201;\nADR:test-address;\nURL:http://2amigos.us;\nNICKNAME:tonydspaniard;\n;";
+        $expected = "MECARD:N:Ramirez Antonio;SOUND:docomotaro;TEL:657657657;TEL-AV:657657657;EMAIL:hola@2amigos.us;" .
+            "NOTE:test-note;BDAY:19711201;ADR:test-address;URL:http://2amigos.us;NICKNAME:tonydspaniard;;";
         $this->tester->assertEquals($expected, $card->getText());
 
         $this->tester->expectException('Da\QrCode\Exception\InvalidConfigException', function() use ($card){


### PR DESCRIPTION
`please do not put line breaks in actual notation`

Source: https://web.archive.org/web/20160304025131/https://www.nttdocomo.co.jp/english/service/developer/make/content/barcode/function/application/addressbook/index.html