### PR TITLE
compatibility with php 7.2 plus

### DIFF
--- a/src/formats/FormatAbstract.php
+++ b/src/formats/FormatAbstract.php
@@ -6,7 +6,7 @@
  */
 namespace dosamigos\qrcode\formats;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Abstract Class FormatAbstract for all formats
@@ -16,7 +16,7 @@ use yii\base\Object;
  * @link http://www.2amigos.us/
  * @package dosamigos\qrcode\formats
  */
-abstract class FormatAbstract extends Object
+abstract class FormatAbstract extends BaseObject
 {
     /**
      * @return string the formatted string to be encoded

--- a/src/lib/Code.php
+++ b/src/lib/Code.php
@@ -7,7 +7,7 @@
 namespace dosamigos\qrcode\lib;
 
 use yii\base\InvalidParamException;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class Code
@@ -20,7 +20,7 @@ use yii\base\Object;
  * @link http://www.2amigos.us/
  * @package dosamigos\qrcode\lib
  */
-class Code extends Object
+class Code extends BaseObject
 {
     /**
      * @var int version

--- a/src/lib/Encode.php
+++ b/src/lib/Encode.php
@@ -7,7 +7,7 @@
 namespace dosamigos\qrcode\lib;
 
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class Encode
@@ -17,7 +17,7 @@ use yii\base\Object;
  * @link http://www.2amigos.us/
  * @package dosamigos\qrcode\lib
  */
-class Encode extends Object
+class Encode extends BaseObject
 {
     /**
      * @var bool whether to be case senstive or not

--- a/src/lib/FrameFiller.php
+++ b/src/lib/FrameFiller.php
@@ -6,7 +6,7 @@
  */
 namespace dosamigos\qrcode\lib;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class FrameFiller
@@ -19,7 +19,7 @@ use yii\base\Object;
  * @link http://www.2amigos.us/
  * @package dosamigos\qrcode\lib
  */
-class FrameFiller extends Object
+class FrameFiller extends BaseObject
 {
     public $width;
     public $frame;

--- a/src/lib/RgbColor.php
+++ b/src/lib/RgbColor.php
@@ -7,7 +7,7 @@
 namespace dosamigos\qrcode\lib;
 
 use yii\base\InvalidParamException;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class RgbColor
@@ -20,7 +20,7 @@ use yii\base\Object;
  * @link http://www.2amigos.us/
  * @package dosamigos\qrcode\lib
  */
-class RgbColor extends Object
+class RgbColor extends BaseObject
 {
     /**
      * @var array


### PR DESCRIPTION
I have a compatibility problem with yii2-qrcode-helper v1.0.3 and PHP 7.2+. The message of error is

`Cannot use yii\base\Object as Object because 'Object' is a special class name`

This error was happened because PHP 7.2 no longer supports 'Object' as a class name. 

Unfortunately I can't upgrade yii2-qrcode-helper till latest version, because the latest one is major

This pull request is patch for 1.0.3 version

Can you create 1.0.4 release please? Thank you!