### PR TITLE
release: correct version to 4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          # GD-only by design: as of v2.0 the library renders QR codes with the
+          # GD-only by design: as of v4.0 the library renders QR codes with the
           # GD backend and no longer depends on imagick. Only gd + simplexml
           # are required at runtime, so imagick is deliberately NOT installed.
           extensions: gd, simplexml
@@ -32,7 +32,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Check coding standards (php-cs-fixer)
-        # Non-blocking: the v2.0 style baseline is still being normalised across
+        # Non-blocking: the v4.0 style baseline is still being normalised across
         # src/, so a failing dry-run should not fail the whole pipeline yet.
         continue-on-error: true
         run: vendor/bin/php-cs-fixer fix --dry-run --diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 2.0.0 - 2026-06-18
+## 4.0.0 - 2026-06-18
 
 ### Added
 - Enh #69: vCard `PHOTO` now supports Base64 / `data:` URIs and local image files, inlined as a `PHOTO:data:<mime>;base64,...` line, in addition to the previous remote-URL behaviour (tonydspaniard)
@@ -10,7 +10,7 @@
 - New framework-agnostic PSR-15 `Da\QrCode\Bridge\Psr\QrCodeAction` (a `RequestHandlerInterface`) for Yii3 and any PSR-15 app (Mezzio, Slim, ...) (tonydspaniard)
 
 ### Changed
-- Reorganized framework adapters under `Da\QrCode\Bridge\<Framework>\` (Yii2, Laravel, Psr); dropped redundant `Laravel` class-name prefixes. See [UPGRADE-2.0](UPGRADE-2.0.md) §7 for the namespace map (tonydspaniard)
+- Reorganized framework adapters under `Da\QrCode\Bridge\<Framework>\` (Yii2, Laravel, Psr); dropped redundant `Laravel` class-name prefixes. See [UPGRADE-4.0](UPGRADE-4.0.md) §7 for the namespace map (tonydspaniard)
 - Enh #73: Require PHP 8.3, 8.4 or 8.5; dropped support for everything below 8.3 (tonydspaniard)
 - Dropped the `marc-mabe/php-enum` dependency; `Enums\*` classes are now plain `final class`es exposing the same `public const` values (tonydspaniard)
 - Bumped `bacon/bacon-qr-code` to `^3` and `khanamiryan/qrcode-detector-decoder` to `^2` (tonydspaniard)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ its use on the framework.
 
 PNG and JPG output is rendered with a pure-GD backend **by default**, so no ImageMagick installation is required. 
 ImageMagick (`ext-imagick`) is **optional** and only needed if you explicitly opt into the Imagick backend — see the 
-[upgrade guide](UPGRADE-2.0.md) and the [troubleshooting guide](docs/helpful-guides/troubleshooting.md).
+[upgrade guide](UPGRADE-4.0.md) and the [troubleshooting guide](docs/helpful-guides/troubleshooting.md).
 
 ## Documentation 
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,6 +1,6 @@
-# Upgrading from 1.x to 2.0
+# Upgrading from 3.x to 4.0
 
-This guide lists every breaking change in **2.0** and what to do about each one. For most
+This guide lists every breaking change in **4.0** and what to do about each one. For most
 applications the upgrade is straightforward: the public API of the formats, the `QrCode`
 class and the `Da\QrCode\Enums\*` constants is unchanged.
 
@@ -21,8 +21,8 @@ class and the `Da\QrCode\Enums\*` constants is unchanged.
 Everything below PHP 8.3 has been dropped. `composer.json` now requires `"php": "^8.3"`,
 so the supported versions are **8.3, 8.4 and 8.5**.
 
-**What to do:** Upgrade your runtime to PHP 8.3 or newer before installing 2.0. If you must stay
-on an older PHP, remain on the 1.x line.
+**What to do:** Upgrade your runtime to PHP 8.3 or newer before installing 4.0. If you must stay
+on an older PHP, remain on the 3.x line.
 
 ## 2. `marc-mabe/php-enum` dependency removed
 
@@ -51,12 +51,12 @@ Previously, `PngWriter` and `JpgWriter` forced the ImageMagick backend, which re
 `ext-imagick` extension and, on some Windows setups, produced the error
 `RegistryKeyLookupFailed 'CoderModulesPath' ... GetMagickModulePath` (issue #68).
 
-As of 2.0, both writers render with a new pure-GD backend
+As of 4.0, both writers render with a new pure-GD backend
 ([`Da\QrCode\Renderer\GdImageBackEnd`](src/Renderer/GdImageBackEnd.php)) **by default**, so only
 `ext-gd` is required (the library already required it).
 
 Because the rendering engine changed, the **raw bytes of generated PNG/JPG images differ slightly**
-from 1.x, even when the QR content is identical.
+from 3.x, even when the QR content is identical.
 
 ImageMagick is still supported as an **opt-in** backend — pass it to the writer constructor:
 
@@ -116,7 +116,7 @@ The framework-specific classes were scattered across `Action/`, `Component/`, `C
 redundant `Laravel` prefixes were dropped. The framework-agnostic core (`QrCode`, `StyleManager`,
 `Writer\*`, `Format\*`, `Renderer\*`, `Factory\WriterFactory`, the `Enums`, etc.) is **unchanged**.
 
-| 1.x class | 2.0 class |
+| 3.x class | 4.0 class |
 | --- | --- |
 | `Da\QrCode\Action\QrCodeAction` | `Da\QrCode\Bridge\Yii2\QrCodeAction` |
 | `Da\QrCode\Component\QrCodeComponent` | `Da\QrCode\Bridge\Yii2\QrCodeComponent` |
@@ -135,7 +135,7 @@ redundant `Laravel` prefixes were dropped. The framework-agnostic core (`QrCode`
 
 ## 8. New: framework-agnostic PSR-15 action (Yii3, Mezzio, Slim, …)
 
-`2.0` adds [`Da\QrCode\Bridge\Psr\QrCodeAction`](src/Bridge/Psr/QrCodeAction.php), a PSR-15
+`4.0` adds [`Da\QrCode\Bridge\Psr\QrCodeAction`](src/Bridge/Psr/QrCodeAction.php), a PSR-15
 `RequestHandlerInterface` that renders a QR from a request parameter and depends only on PSR-7/PSR-17
 interfaces. Use it with **Yii3** or any PSR-15 application. It requires `psr/http-message`,
 `psr/http-factory` and `psr/http-server-handler` (all listed under `suggest`).

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "4.0-dev"
         },
         "laravel": {
             "providers": [

--- a/docs/helpful-guides/troubleshooting.md
+++ b/docs/helpful-guides/troubleshooting.md
@@ -16,7 +16,7 @@ ImagickException: RegistryKeyLookupFailed `CoderModulesPath' @ error/module.c/Ge
 
 ### Why it happened
 
-In 1.x, `PngWriter` and `JpgWriter` **forced** the ImageMagick (Imagick) backend. That required the
+In 3.x, `PngWriter` and `JpgWriter` **forced** the ImageMagick (Imagick) backend. That required the
 `ext-imagick` extension to be installed *and correctly configured*. When ImageMagick could not
 locate its coder modules (a common misconfiguration on Windows), Imagick threw the
 `RegistryKeyLookupFailed 'CoderModulesPath'` error and no image could be produced.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,8 @@ it uses a modified version of its code for the writers included on this package.
 ### Supported PHP Versions  
 | Tag | PHP Version |
 | :---: |:----------:|
-| ^1.1 |  7.3 - 8.x |
-| ^2.0 |  8.3 - 8.5 |
+| 3.x  |  7.3 - 8.1 |
+| ^4.0 |  8.3 - 8.5 |
 
 ### Server Requirements
 
@@ -33,14 +33,14 @@ The preferred way to install this extension is through [composer](http://getcomp
 Either run
 
 ```
-php composer.phar require 2amigos/qrcode-library:^2.0
+php composer.phar require 2amigos/qrcode-library:^4.0
 ```
 or add
 
 ```json
 {
   ...
-  "2amigos/qrcode-library": "^2.0"
+  "2amigos/qrcode-library": "^4.0"
 }
 ```
 


### PR DESCRIPTION
## Correct the release version: `4.0.0` (not `2.0.0`)

PR #75 shipped this release labeled **2.0.0**, but that came from the repo's **stale**
`CHANGELOG`/`branch-alias` (which read 1.1.x). The actual latest published release is **3.1.0**,
and this work is built directly on top of it (the diff from the `3.1.0` tag to the merge base was
just a couple of lines). With the breaking changes in this release — minimum PHP **8.3**, the
`Da\QrCode\Bridge\*` namespace reorganization, GD-by-default rendering, and the `marc-mabe/php-enum`
removal — the correct next version is **`4.0.0`**.

### Changes
- Rename `UPGRADE-2.0.md` → `UPGRADE-4.0.md` ("Upgrading from **3.x** to **4.0**"; documented breaks are accurate vs 3.1.0).
- `CHANGELOG.md`: `## 2.0.0` → `## 4.0.0`.
- `composer.json` branch-alias `2.0-dev` → `4.0-dev`.
- `docs/index.md`: install `^4.0` + version table.
- `README.md` / CI comments: link + version text.

No code changes — metadata/docs only. Merge this, then `4.0.0` gets tagged.
