### PR TITLE
docs: modernize Read the Docs site and align content with 4.0

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,16 @@
+# Read the Docs build configuration.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 
 build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
+
 mkdocs:
   configuration: mkdocs.yml
+
+# Install the theme + extensions so the Material build matches local `mkdocs serve`.
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/contributing/clean-code.md
+++ b/docs/contributing/clean-code.md
@@ -50,6 +50,3 @@ Running Tests
 We are using `PHPUnit` for testing the module. Do the following: 
 
 - Run `./vendor/bin/phpunit`
-
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/contributing/how-to.md
+++ b/docs/contributing/how-to.md
@@ -27,6 +27,3 @@ All contributions should follow our [templates guidelines](https://github.com/2a
 ## Clean Code
 
 - Follow the guidelines at [Clean Code](clean-code.md) 
-
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/bitcoin.md
+++ b/docs/formats/bitcoin.md
@@ -27,5 +27,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/bookmark.md
+++ b/docs/formats/bookmark.md
@@ -12,9 +12,9 @@ Usage
 ```php 
 
 use Da\QrCode\QrCode;
-use Da\QrCode\Format\BookmarkFormat; 
+use Da\QrCode\Format\BookMarkFormat; 
 
-$format = new BookMarkFormat(['title' => '2amigos', 'url' => 'http://2am.tech']);
+$format = new BookMarkFormat(['title' => '2am.tech', 'url' => 'http://2am.tech']);
 
 $qrCode = new QrCode($format);
 
@@ -23,5 +23,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/geo.md
+++ b/docs/formats/geo.md
@@ -25,5 +25,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/ical.md
+++ b/docs/formats/ical.md
@@ -21,5 +21,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/mail-message.md
+++ b/docs/formats/mail-message.md
@@ -14,7 +14,7 @@ Usage
 use Da\QrCode\QrCode;
 use Da\QrCode\Format\MailMessageFormat; 
 
-$format = new MailMessageFormat(['email' => 'hola@2amigos.us', 'subject' => 'test', 'body' => 'test-body']);
+$format = new MailMessageFormat(['email' => 'hola@2am.tech', 'subject' => 'test', 'body' => 'test-body']);
 
 $qrCode = new QrCode($format);
 
@@ -23,5 +23,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/mail-to.md
+++ b/docs/formats/mail-to.md
@@ -1,9 +1,9 @@
 MailToFormat
 ------------
 
-To encode an e-mail address like sean@example.com, one could simply encode hola@2amigos.us. However to ensure it is 
+To encode an e-mail address like sean@example.com, one could simply encode hola@2am.tech. However to ensure it is 
 recognized as an e-mail address, it is advisable to create a proper mailto: URI from the address: 
-`mailto:hola@2amigos.us`.
+`mailto:hola@2am.tech`.
 
 This class helps to enforce the above rule. 
 
@@ -13,9 +13,9 @@ Usage
 ```php 
 
 use Da\QrCode\QrCode;
-use Da\QrCode\Format\MailtoFormat; 
+use Da\QrCode\Format\MailToFormat; 
 
-$format = new MailToFormat(['email' => 'hola@2amigos.us']);
+$format = new MailToFormat(['email' => 'hola@2am.tech']);
 
 $qrCode = new QrCode($format);
 
@@ -23,5 +23,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/me-card.md
+++ b/docs/formats/me-card.md
@@ -23,7 +23,7 @@ $format->lastName = 'Ramirez';
 $format->sound = 'docomotaro';
 $format->phone = '657657XXX';
 $format->videoPhone = '657657XXX';
-$format->email = 'hola@2amigos.us';
+$format->email = 'hola@2am.tech';
 $format->note = 'test-note';
 $format->birthday = '19791201';
 $format->address = 'test-address';
@@ -41,12 +41,10 @@ echo $qrCode->writeString();
 Organization
 ------------
 
-Since **2.0** (#34) you can set an `organization`, which is emitted as an `ORG:` entry. It is only
+Since **4.0** (#34) you can set an `organization`, which is emitted as an `ORG:` entry. It is only
 added when set, so existing output is unaffected.
 
 ```php
-$format->organization = '2amigos';
-// adds: ORG:2amigos;
+$format->organization = '2am.tech';
+// adds: ORG:2am.tech;
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/mms.md
+++ b/docs/formats/mms.md
@@ -23,5 +23,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/phone.md
+++ b/docs/formats/phone.md
@@ -26,5 +26,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/sms.md
+++ b/docs/formats/sms.md
@@ -21,5 +21,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/vcard.md
+++ b/docs/formats/vcard.md
@@ -16,7 +16,7 @@ use Da\QrCode\Format\VCardFormat;
 $format = new VCardFormat();
 $format->name = "Antonio";
 $format->fullName = "Antonio Ramirez";
-$format->email = "hola@2amigos.us";
+$format->email = "hola@2am.tech";
 
 $qrCode = new QrCode($format);
 
@@ -29,7 +29,7 @@ echo $qrCode->writeString();
 Photo
 -----
 
-Since **2.0** (#69) the `photo` property accepts more than a remote URL. It is interpreted in the
+Since **4.0** (#69) the `photo` property accepts more than a remote URL. It is interpreted in the
 following order of precedence:
 
 - a ready `data:` URI (e.g. `data:image/png;base64,...`) — embedded inline as-is;
@@ -38,14 +38,12 @@ following order of precedence:
   referenced by URL, the historical behaviour.
 
 ```php
-// Inline a local image file as Base64 (new in 2.0)
+// Inline a local image file as Base64 (new in 4.0)
 $format->photo = '/path/to/avatar.png';
 
-// Inline a ready data URI as-is (new in 2.0)
+// Inline a ready data URI as-is (new in 4.0)
 $format->photo = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...';
 
 // Reference a remote image by URL (back-compatible)
 $format->photo = 'https://example.com/avatar.png';
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/wifi.md
+++ b/docs/formats/wifi.md
@@ -33,5 +33,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/formats/youtube.md
+++ b/docs/formats/youtube.md
@@ -20,5 +20,3 @@ header('Content-Type: ' . $qrCode->getContentType());
 echo $qrCode->writeString();
 
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/helpful-guides/advance-usage.md
+++ b/docs/helpful-guides/advance-usage.md
@@ -16,7 +16,7 @@ Remembering that fact, we can configure and use our instance like this:
 // A label can be a string OR a Da\Contracts\LabelInterface instance. 
 // Using the instance, we will have more control on how do we want the label to be displayed.
 // Immutability also applies to this class! 
-$label = (new Label('2amigos'))
+$label = (new Label('2am.tech'))
     ->setFont(__DIR__ . '/../resources/fonts/monsterrat.otf')
     ->setFontSize(12);
 
@@ -101,5 +101,3 @@ $qrCode = (new QrCode('https://2am.tech'))
 
 The default value for the intensity is 1. It must be a number between 0 and 1,
 otherwise an exception will be thrown.
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/helpful-guides/troubleshooting.md
+++ b/docs/helpful-guides/troubleshooting.md
@@ -21,10 +21,10 @@ In 3.x, `PngWriter` and `JpgWriter` **forced** the ImageMagick (Imagick) backend
 locate its coder modules (a common misconfiguration on Windows), Imagick threw the
 `RegistryKeyLookupFailed 'CoderModulesPath'` error and no image could be produced.
 
-### The fix in 2.0
+### The fix in 4.0
 
-As of 2.0 the writers render with a **pure-GD backend by default**
-([`Da\QrCode\Renderer\GdImageBackEnd`](../../src/Renderer/GdImageBackEnd.php)), so PNG and JPG output
+As of 4.0 the writers render with a **pure-GD backend by default**
+([`Da\QrCode\Renderer\GdImageBackEnd`](https://github.com/2amigos/qrcode-library/blob/master/src/Renderer/GdImageBackEnd.php)), so PNG and JPG output
 only needs `ext-gd`, which the library already requires. **The error no longer occurs out of the
 box** — you do not need ImageMagick at all.
 
@@ -42,7 +42,7 @@ avoids the ImageMagick configuration headache entirely.
 ### If you explicitly opt into ImageMagick
 
 ImageMagick is still supported as an opt-in backend. Pass it to the writer constructor (see
-[`PngWriter`](../../src/Writer/PngWriter.php) / [`JpgWriter`](../../src/Writer/JpgWriter.php)):
+[`PngWriter`](https://github.com/2amigos/qrcode-library/blob/master/src/Writer/PngWriter.php) / [`JpgWriter`](https://github.com/2amigos/qrcode-library/blob/master/src/Writer/JpgWriter.php)):
 
 ```php
 use Da\QrCode\QrCode;
@@ -120,6 +120,3 @@ echo '<img src="' . $qrCode->writeDataUri() . '" alt="QR code">';
 ```
 
 Both approaches use the default GD backend, so neither requires ImageMagick.
-
-
-© [2amigos](https://2am.tech/)

--- a/docs/helpful-guides/working-with-qrcode-component-and-qrcode-action.md
+++ b/docs/helpful-guides/working-with-qrcode-component-and-qrcode-action.md
@@ -9,7 +9,7 @@ First we need to configure the component in our Yii2 application config file on 
 // ... 
     'qr' => [
         'class' => '\Da\QrCode\Bridge\Yii2\QrCodeComponent',
-        'label' => '2amigos consulting group llc',
+        'label' => '2am.tech',
         'size' => 500 // big and nice :D
         // ... you can configure more properties of the component here
     ]
@@ -26,10 +26,10 @@ public function actions()
 {
     return [
         'qr' => [
-            'class' => QrCodeAction::className(),
+            'class' => \Da\QrCode\Bridge\Yii2\QrCodeAction::class,
             'text' => 'https://2am.tech', // default text
             'param' => 'v',
-            'commponent' => 'qr' // if configured in our app as `qr` 
+            'component' => 'qr' // if configured in our app as `qr` 
         ]
     ];
 }
@@ -44,5 +44,3 @@ QrCode. According to the above configuration we could use it to display it on im
 <!-- this will display https://2am.tech (default text) -->
 <img src="<?= Url::to(['controller/qr']) ?>" />
 ```
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,10 @@
 # Qrcode Library
 
-[![Documentation Status](https://readthedocs.org/projects/qrcode-library/badge/?version=latest)](http://qrcode-library.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/qrcode-library/badge/?version=latest)](https://qrcode-library.readthedocs.io/en/latest/?badge=latest)
 [![Packagist Version](https://img.shields.io/packagist/v/2amigos/qrcode-library.svg?style=flat-square)](https://packagist.org/packages/2amigos/qrcode-library)
-[![Build Status](https://travis-ci.org/2amigos/qrcode-library.svg?branch=master)](https://travis-ci.org/2amigos/qrcode-library)
+[![tests](https://github.com/2amigos/qrcode-library/actions/workflows/ci.yml/badge.svg)](https://github.com/2amigos/qrcode-library/actions/workflows/ci.yml)
 [![Latest Stable Version](https://poser.pugx.org/2amigos/qrcode-library/version)](https://packagist.org/packages/2amigos/qrcode-library)
 [![Total Downloads](https://poser.pugx.org/2amigos/qrcode-library/downloads)](https://packagist.org/packages/2amigos/qrcode-library)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/2amigos/qrcode-library/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/2amigos/qrcode-library/?branch=master)
 
 The library provides developers with the tools to generate Qr codes with ease. It is a total refactored version of the 
 previous named yii2-qrcode-helper which was based on the ported PHP version of the libqrencode C library.  
@@ -79,18 +78,18 @@ You can set the foreground color, defining RGBA values, where the alpha is optio
 
 ```PHP
 $qrCode = (new QrCode('This is my text'))
-    ->setForeground(0, 0, 0);
+    ->setForegroundColor(0, 0, 0);
 
 // or, setting alpha as well
 $qrCode = (new QrCode('This is my text'))
-    ->setForeground(0, 0, 0, 50);
+    ->setForegroundColor(0, 0, 0, 50);
 ```
 
 ### Formats
 
 In order to ease the task to write different formats into a QrCode, the library comes with a set of classes. These are: 
 
--  [BookmarkFormat](formats/bookmark.md)
+-  [BookMarkFormat](formats/bookmark.md)
 -  [BtcFormat](formats/bitcoin.md) 
 -  [GeoFormat](formats/geo.md)
 -  [ICalFormat](formats/ical.md)
@@ -141,6 +140,3 @@ Contributing
 
 -  [How to Contribute](contributing/how-to.md)
 -  [Clean Code](contributing/clean-code.md)
-
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/docs/laravel/blade-component.md
+++ b/docs/laravel/blade-component.md
@@ -23,9 +23,9 @@ It has only `content` as a required field.
 <x-2am-qrcode :content="'2am. Technologies'"/>
 ```
 
-We can also define the qrcode [format](../index.md#Formats). To do so,
-you must specify the `format` attribute with a constant from `\Da\QrCode\Enum\Format` and the `content` as an array,
-fulfilling the data for the designed format as specified in the format [docs]((../index.md#Formats)).
+We can also define the qrcode [format](../index.md#formats). To do so,
+you must specify the `format` attribute with a constant from `\Da\QrCode\Enums\Format` and the `content` as an array,
+fulfilling the data for the designed format as specified in the format [docs](../index.md#formats).
 
 To work with colors (background, foreground and gradient foreground), you set
 the attributes `background`, `foregroud` and `foreground2` (for gradient foreground) as an array
@@ -71,11 +71,11 @@ All blade component attributes:
 | Attribute |                                Description                                 |                   Data Type                    |
 |:---------:|:--------------------------------------------------------------------------:|:----------------------------------------------:|
 |  content  |                         Defines the qrcode's data                          |                 string; array                  |
-| format |                        Defines the qrcode's format                         |             \Da\QrCode\Enum\Format             |
+| format |                        Defines the qrcode's format                         |             \Da\QrCode\Enums\Format             |
 | foreground |                 Defines the qrcode`s foreground base color                 |               array (r, g, b, a)               |
 | background |                   Defines the qrcode's background color                    |               array (r, g, b, a)               |
 | foreground2 |       Defines the qrcode's foreground end color (turns to gradient)        |               array (r, g, b, a)               |
-| pathStyle |                      Defines the qrcode's path style                       |              \Da\QrCode\Enum\Path              |
+| pathStyle |                      Defines the qrcode's path style                       |              \Da\QrCode\Enums\Path              |
 | intensity |                      Defines the path style intensity                      |              float, from 0.1 to 1              |
 | margin |                        Defines the qrcode's margin                         |                      int                       |
 | size |                         Defines the qrcode's size                          |                      int                       |
@@ -86,4 +86,4 @@ All blade component attributes:
 | label |                         Defines the qrcode's label                         | string |
 | font |                           Defines the label font                           | string. It should be full path |
 | fontSize |                        Defines the label font size                         | int |
-| fontAlign | Defines the label alignment | \Da\QrCode\Label |
+| fontAlign | Defines the label alignment | \Da\QrCode\Enums\Label |

--- a/docs/psr/qrcode-action.md
+++ b/docs/psr/qrcode-action.md
@@ -38,7 +38,7 @@ $action = (new QrCodeAction($responseFactory, $streamFactory))
     ->withForegroundColor(20, 30, 90)
     ->withBackgroundColor(255, 255, 255)
     ->withLogo(__DIR__ . '/logo.png', 90)
-    ->withLabel('2amigos')
+    ->withLabel('2am.tech')
     ->withWriter(new \Da\QrCode\Writer\SvgWriter()); // default writer is PNG (GD)
 ```
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+# Documentation build dependencies (Read the Docs / local `mkdocs serve`).
+# Material for MkDocs pulls in mkdocs and pymdown-extensions transitively.
+mkdocs-material>=9.5,<10

--- a/docs/yii/qrcode-action.md
+++ b/docs/yii/qrcode-action.md
@@ -20,15 +20,13 @@ public function actions()
 {
     return [
         'qr' => [
-            'class' => QrCodeAction::className(),
+            'class' => \Da\QrCode\Bridge\Yii2\QrCodeAction::class,
             'text' => 'https://2am.tech',
             'param' => 'v',
-            'commponent' => 'qr' // if configured in our app as `qr` 
+            'component' => 'qr' // if configured in our app as `qr` 
         ]
     ];
 }
 ```
 
-See [QrCodComponent](qrcode-component.md).
-
-© [2amigos](https://2am.tech/) 2013-2023
+See [QrCodeComponent](qrcode-component.md).

--- a/docs/yii/qrcode-component.md
+++ b/docs/yii/qrcode-component.md
@@ -34,10 +34,7 @@ Yii::$app->response->headers->add('Content-Type', $qr->getContentType());
 
 return $qr
     ->setText('https://2am.tech')
-    ->setLabel('2amigos consulting group llc')
+    ->setLabel('2am.tech')
     ->writeString();
 
 ```
-
-
-© [2amigos](https://2am.tech/) 2013-2023

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,92 @@
 site_name: QrCode Library
+site_description: >-
+  Generate QR codes with ease in PHP. Works standalone and ships bridges for
+  Laravel, Yii2 and Yii3 / PSR-15.
+site_url: https://qrcode-library.readthedocs.io/
 repo_url: https://github.com/2amigos/qrcode-library
-edit_uri: docs/master/
+repo_name: 2amigos/qrcode-library
+edit_uri: edit/master/docs/
+copyright: Copyright &copy; 2013–2026 2am.tech
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Formats:
+      - Bitcoin (BTC): formats/bitcoin.md
+      - Bookmark (MEBKM): formats/bookmark.md
+      - Geo location: formats/geo.md
+      - iCal event: formats/ical.md
+      - Mail message: formats/mail-message.md
+      - Mailto: formats/mail-to.md
+      - MeCard: formats/me-card.md
+      - MMS: formats/mms.md
+      - Phone: formats/phone.md
+      - SMS: formats/sms.md
+      - vCard: formats/vcard.md
+      - Wi-Fi: formats/wifi.md
+      - YouTube: formats/youtube.md
+  - Laravel:
+      - Blade component: laravel/blade-component.md
+      - File route: laravel/file-route.md
+      - Customization: laravel/customization.md
+  - Yii2:
+      - QrCode component: yii/qrcode-component.md
+      - QrCode action: yii/qrcode-action.md
+  - Yii3 / PSR-15:
+      - PSR-15 action: psr/qrcode-action.md
+  - Helpful guides:
+      - Advanced usage: helpful-guides/advance-usage.md
+      - Components & actions: helpful-guides/working-with-qrcode-component-and-qrcode-action.md
+      - Troubleshooting: helpful-guides/troubleshooting.md
+  - Contributing:
+      - How to contribute: contributing/how-to.md
+      - Clean code: contributing/clean-code.md


### PR DESCRIPTION
## Summary
Rebuilds the Read the Docs site and brings the documentation content in line with the 4.0 release. Documentation-only: no `src/`, `composer.json`, or runtime changes.

## Site / build
- Replace the 3-line `mkdocs.yml` with a **Material for MkDocs** setup: explicit navigation, light/dark toggle, search, code-copy buttons, syntax highlighting, repo + per-page edit links, and a site-wide footer.
- `.readthedocs.yaml` now installs `docs/requirements.txt`, so the RTD build matches local `mkdocs serve` (the Material theme must be installed for the build to succeed).

## Content fixes
- **Broken API examples:** `setForeground` → `setForegroundColor`; correct `BookMarkFormat` / `MailToFormat` import casing (wrong casing broke PSR-4 autoload on case-sensitive filesystems); singular `Enum` → plural `Enums`; `fontAlign` now references `Enums\Label`.
- Drop the removed Yii1-era `QrCodeAction::className()` in favour of `::class`; fix the `commponent` typo.
- **Broken links:** `#Formats` → `#formats` anchors, a double-paren link, and `../../src/*.php` links → GitHub URLs (src is not published with the docs).
- Replace the dead Travis badge with the GitHub Actions badge; drop the dead Scrutinizer badge.
- Stale `2.0` → `4.0` version references; bump footer year.
- Rebrand display names and example emails to `2am.tech` (Packagist package name and GitHub slug intentionally unchanged).

## Test plan
- [x] `mkdocs build --strict` passes (exit 0, 25 pages, no link/nav/anchor warnings) with mkdocs 1.6.1 / mkdocs-material 9.7.x.
- [ ] Read the Docs build turns green for this branch (Builds tab on readthedocs.org).
- [ ] Spot-check rendered nav, dark/light toggle, and code-copy on the published preview.