### PR TITLE
release: 4.0.0 final polish + Dependabot alert cleanup (#78, #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ImageMagick (`ext-imagick`) is **optional** and only needed if you explicitly op
 
 ## Documentation 
 
-You can read the latest docs on [http://qrcode-library.readthedocs.io/en/latest/](http://qrcode-library.readthedocs.io/en/latest/)
+You can read the latest docs on [https://qrcode-library.readthedocs.io/en/latest/](https://qrcode-library.readthedocs.io/en/latest/)
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "codeception/specify": "^2.0",
         "codeception/verify": "^3.0",
         "yiisoft/yii2": "^2.0.52",
-        "laravel/framework": "^12.0",
+        "laravel/framework": "^12.61.1",
         "psr/http-message": "^2.0",
         "psr/http-factory": "^1.0",
         "nyholm/psr7": "^1.8",

--- a/tests/_laravel/package.json
+++ b/tests/_laravel/package.json
@@ -10,7 +10,7 @@
         "production": "mix --production"
     },
     "devDependencies": {
-        "axios": "^0.21",
+        "axios": "^1.8.2",
         "laravel-mix": "^6.0.6",
         "lodash": "^4.17.19",
         "postcss": "^8.1.14"


### PR DESCRIPTION
## Summary

Finalizes the **4.0.0** release on top of the already-merged PHP 8.3–8.5 work, and clears the outstanding Dependabot alerts so the 4.0 line ships clean. Once this merges to `master`, the remaining 19 open alerts auto-close.

## Security — closes #78 and #79

Both affected dependencies are **dev/test-only** (`require-dev` / the Laravel test fixture) and are **not** shipped with the published `2amigos/qrcode-library` Composer package, so consumers were never exposed. Because neither lockfile is committed (`composer.lock` and the fixture's JS lockfile are gitignored), Dependabot evaluates the manifest constraints directly — so each fix raises the manifest's lower bound above the advisories' fixed versions.

- **#78 — axios (17 alerts):** `tests/_laravel/package.json` bumped `axios ^0.21` → `^1.8.2`. The `>= 1.8.2` floor matters: GHSA-jr5f-v2jv-69x6 affects axios 1.x **< 1.8.2**, so a plain `^1.x` could leave it open. Resolves to the current 1.18.0. Fixture usage (`window.axios = require('axios')` + `axios.defaults.headers`) is unchanged in axios v1.
- **#79 — laravel/framework (2 alerts):** `composer.json` `require-dev` bumped `^12.0` → `^12.61.1`, above the fixed versions for GHSA-5vg9-5847-vvmq (12.60.0) and GHSA-crmm-hgp2-wgrp (12.61.1). The third advisory in #79, GHSA-78fx-h6xr-vch4, targets the Laravel **10.x** line and was **dismissed** as not applicable to the `^12.0` constraint.

> Note: #79 originally assumed a committed `composer.lock` pinning 12.62.0 would auto-close the alerts. Since `composer.lock` is gitignored, tightening the `composer.json` constraint is what actually clears them.

## Docs

- Modernized the Read the Docs site and aligned content with 4.0.
- README: Read the Docs link switched `http` → `https`.

## Test plan

- [x] CI green on this branch (PHP 8.3 / 8.4 / 8.5 matrix)
- [x] Laravel bridge codeception suite passes with `laravel/framework ^12.61.1`
- [x] After merge to `master`: confirm the 17 axios + 2 Laravel 12.x Dependabot alerts auto-close
- [x] Confirm alert #5 (GHSA-78fx-h6xr-vch4) stays dismissed
